### PR TITLE
Use test suites

### DIFF
--- a/libs/community/langchain_community/vectorstores/aperturedb.py
+++ b/libs/community/langchain_community/vectorstores/aperturedb.py
@@ -235,8 +235,10 @@ class ApertureDB(VectorStore):
         ]
 
         results, _ = self.utils.execute(query)
-        docs = [self._descriptor_to_document(d) 
-            for d in results[0]["FindDescriptor"].get("entities", [])]
+        docs = [
+            self._descriptor_to_document(d) 
+            for d in results[0]["FindDescriptor"].get("entities", [])
+        ]
         return docs
 
     @override
@@ -481,7 +483,7 @@ class ApertureDB(VectorStore):
         ]
         if ids_to_delete:
             self.delete(ids_to_delete)
-        
+
         texts = [doc.page_content for doc in items]
         metadatas = [
             doc.metadata if getattr(doc, "metadata", None) is not None else {}
@@ -512,3 +514,4 @@ class ApertureDB(VectorStore):
         loader = ParallelLoader(self.connection)
         loader.ingest(data, batchsize=BATCHSIZE)
         return UpsertResponse(succeeded=ids, failed=[])
+        

--- a/libs/community/langchain_community/vectorstores/aperturedb.py
+++ b/libs/community/langchain_community/vectorstores/aperturedb.py
@@ -192,81 +192,6 @@ class ApertureDB(VectorStore):
             self.utils.create_entity_index("_Descriptor", UNIQUEID_PROPERTY)
 
     @override
-    def add_documents(self, documents: List[Document], **kwargs: Any) -> List[str]:
-        """Adds documents to the vectorstore with embeddings
-
-        Args:
-            documents: List of Document objects to add to the vectorstore.
-
-        Returns:
-            List of ids from adding the documents into the vectorstore.
-        """
-        from aperturedb.ParallelLoader import ParallelLoader
-
-        texts = [doc.page_content for doc in documents]
-        metadatas = [
-            doc.metadata if getattr(doc, "metadata", None) is not None else {}
-            for doc in documents
-        ]
-        embeddings = self.embedding_function.embed_documents(texts)
-        ids: List[str] = [
-            doc.id if hasattr(doc, "id") and doc.id is not None else str(uuid.uuid4())
-            for doc in documents
-        ]
-
-        data = []
-        for text, embedding, metadata, unique_id in zip(
-            texts, embeddings, metadatas, ids
-        ):
-            properties = {PROPERTY_PREFIX + k: v for k, v in metadata.items()}
-            properties[TEXT_PROPERTY] = text
-            properties[UNIQUEID_PROPERTY] = unique_id
-            command = {
-                "AddDescriptor": {
-                    "set": self.descriptor_set,
-                    "properties": properties,
-                }
-            }
-            query = [command]
-            blobs = [np.array(embedding, dtype=np.float32).tobytes()]
-            data.append((query, blobs))
-        loader = ParallelLoader(self.connection)
-        loader.ingest(data, batchsize=BATCHSIZE)
-        return ids
-
-    @override
-    def add_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        **kwargs: Any,
-    ) -> List[str]:
-        """Creates embeddings of texts, then adds each text object, its embedding and
-        associated metadata to aperturedb
-
-        Args:
-            texts: Iterable of strings to add to the vectorstore.
-            metadatas: Optional list of metadatas associated with the texts.
-
-        Returns:
-            List of ids from adding the texts into the vectorstore.
-        """
-        texts2: List[str] = list(texts)
-        if metadatas is not None:
-            assert len(texts2) == len(
-                metadatas
-            ), "Length of texts and metadatas should be the same"
-
-            docs = [
-                Document(page_content=text, metadata=metadata)
-                for text, metadata in zip(texts2, metadatas)
-            ]
-        else:
-            docs = [Document(page_content=text) for text in texts2]
-
-        return self.add_documents(docs)
-
-    @override
     def delete(self, ids: Optional[List[str]] = None, **kwargs: Any) -> Optional[bool]:
         """Delete documents from the vectorstore by id.
 
@@ -288,6 +213,31 @@ class ApertureDB(VectorStore):
 
         result, _ = self.utils.execute(query)
         return result
+
+    @override
+    def get_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+        """Find documents in the vectorstore by id.
+
+        Args:
+            ids: List of ids to find in the vectorstore.
+
+        Returns:
+            documents: List of Document objects found in the vectorstore.
+        """
+        query = [
+            {
+                "FindDescriptor": {
+                    "set": self.descriptor_set,
+                    "constraints": {UNIQUEID_PROPERTY: ["in", ids]},
+                    "results": {"all_properties": True},
+                }
+            }
+        ]
+
+        results, _ = self.utils.execute(query)
+        docs = [self._descriptor_to_document(d) 
+            for d in results[0]["FindDescriptor"].get("entities", [])]
+        return docs
 
     @override
     def similarity_search(
@@ -513,6 +463,7 @@ class ApertureDB(VectorStore):
         """Insert or update items
 
         Updating documents is dependent on the documents' `id` attribute.
+        
         Args:
             items: List of Document objects to upsert
 
@@ -522,10 +473,42 @@ class ApertureDB(VectorStore):
         # For now, simply delete and add
         # We could do something more efficient to update metadata,
         # but we don't support changing the embedding of a descriptor.
-        ids: List[str] = [
+
+        from aperturedb.ParallelLoader import ParallelLoader
+
+        ids_to_delete: List[str] = [
             item.id for item in items if hasattr(item, "id") and item.id is not None
         ]
-        if ids:
-            self.delete(ids)
-        ids = self.add_documents(list(items))
+        if ids_to_delete:
+            self.delete(ids_to_delete)
+        
+        texts = [doc.page_content for doc in items]
+        metadatas = [
+            doc.metadata if getattr(doc, "metadata", None) is not None else {}
+            for doc in items
+        ]
+        embeddings = self.embedding_function.embed_documents(texts)
+        ids: List[str] = [
+            doc.id if hasattr(doc, "id") and doc.id is not None else str(uuid.uuid4())
+            for doc in items
+        ]
+
+        data = []
+        for text, embedding, metadata, unique_id in zip(
+            texts, embeddings, metadatas, ids
+        ):
+            properties = {PROPERTY_PREFIX + k: v for k, v in metadata.items()}
+            properties[TEXT_PROPERTY] = text
+            properties[UNIQUEID_PROPERTY] = unique_id
+            command = {
+                "AddDescriptor": {
+                    "set": self.descriptor_set,
+                    "properties": properties,
+                }
+            }
+            query = [command]
+            blobs = [np.array(embedding, dtype=np.float32).tobytes()]
+            data.append((query, blobs))
+        loader = ParallelLoader(self.connection)
+        loader.ingest(data, batchsize=BATCHSIZE)
         return UpsertResponse(succeeded=ids, failed=[])

--- a/libs/community/langchain_community/vectorstores/aperturedb.py
+++ b/libs/community/langchain_community/vectorstores/aperturedb.py
@@ -236,7 +236,7 @@ class ApertureDB(VectorStore):
 
         results, _ = self.utils.execute(query)
         docs = [
-            self._descriptor_to_document(d) 
+            self._descriptor_to_document(d)
             for d in results[0]["FindDescriptor"].get("entities", [])
         ]
         return docs
@@ -514,4 +514,3 @@ class ApertureDB(VectorStore):
         loader = ParallelLoader(self.connection)
         loader.ingest(data, batchsize=BATCHSIZE)
         return UpsertResponse(succeeded=ids, failed=[])
-        

--- a/libs/community/langchain_community/vectorstores/aperturedb.py
+++ b/libs/community/langchain_community/vectorstores/aperturedb.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 # Third-party imports
 import numpy as np
@@ -463,7 +463,7 @@ class ApertureDB(VectorStore):
         """Insert or update items
 
         Updating documents is dependent on the documents' `id` attribute.
-        
+
         Args:
             items: List of Document objects to upsert
 

--- a/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
@@ -3,13 +3,13 @@
 import uuid
 
 import pytest
-
 from langchain_standard_tests.integration_tests.vectorstores import (
     AsyncReadWriteTestSuite,
     ReadWriteTestSuite,
 )
 
 from langchain_community.vectorstores import ApertureDB
+
 
 class TestApertureDBReadWriteTestSuite(ReadWriteTestSuite):
     @pytest.fixture

--- a/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
@@ -1,7 +1,6 @@
 """Test ApertureDB functionality."""
 
 import uuid
-from typing import List, Optional
 
 import pytest
 from langchain_core.documents import Document
@@ -11,11 +10,6 @@ from langchain_standard_tests.integration_tests.vectorstores import (
 )
 
 from langchain_community.vectorstores import ApertureDB
-from tests.integration_tests.vectorstores.fake_embeddings import (
-    FakeEmbeddings,
-    fake_texts,
-)
-
 
 class TestApertureDBReadWriteTestSuite(ReadWriteTestSuite):
     @pytest.fixture
@@ -31,4 +25,3 @@ class TestAsyncApertureDBReadWriteTestSuite(AsyncReadWriteTestSuite):
         descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
         return ApertureDB(embeddings=self.get_embeddings(),
             descriptor_set=descriptor_set)
-            

--- a/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
@@ -3,7 +3,7 @@
 import uuid
 
 import pytest
-from langchain_core.documents import Document
+
 from langchain_standard_tests.integration_tests.vectorstores import (
     AsyncReadWriteTestSuite,
     ReadWriteTestSuite,

--- a/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
@@ -3,7 +3,12 @@
 import uuid
 from typing import List, Optional
 
+import pytest
 from langchain_core.documents import Document
+from langchain_standard_tests.integration_tests.vectorstores import (
+    AsyncReadWriteTestSuite,
+    ReadWriteTestSuite,
+)
 
 from langchain_community.vectorstores import ApertureDB
 from tests.integration_tests.vectorstores.fake_embeddings import (
@@ -12,212 +17,18 @@ from tests.integration_tests.vectorstores.fake_embeddings import (
 )
 
 
-def _aperturedb_from_texts(
-    metadatas: Optional[List[dict]] = None, ids: Optional[List[str]] = None
-) -> ApertureDB:
-    """Create an ApertureDB instance from fake texts."""
-    descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
-    assert metadatas is None or len(metadatas) == len(fake_texts)
-    assert ids is None or len(ids) == len(fake_texts)
-    if ids is None:
-        return ApertureDB.from_texts(
-            fake_texts,
-            FakeEmbeddings(),
-            metadatas=metadatas,
-            descriptor_set=descriptor_set,
-        )
-    else:  # to supply ids, we have to use the Document class
-        if metadatas is None:
-            docs = [
-                Document(page_content=text, id=id_)
-                for text, id_ in zip(fake_texts, ids)
-            ]
-        else:
-            docs = [
-                Document(page_content=text, id=id_, metadata=metadata)
-                for text, id_, metadata in zip(fake_texts, ids, metadatas)
-            ]
-        return ApertureDB.from_documents(
-            docs,
-            FakeEmbeddings(),
-            descriptor_set=descriptor_set,
-        )
+class TestApertureDBReadWriteTestSuite(ReadWriteTestSuite):
+    @pytest.fixture
+    def vectorstore(self) -> ApertureDB:
+        descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
+        return ApertureDB(embeddings=self.get_embeddings(),
+            descriptor_set=descriptor_set)
 
 
-def _compare_documents(actuals: List[Document], expecteds: List[Document]) -> None:
-    """Compare two documents, with one-sided test on IDs.
-    If we don't provide an ID, one will be generated for us, and we don't care what
-    it is."""
-    assert len(actuals) == len(
-        expecteds
-    ), f"Expected {expecteds} results, got {actuals}"
-    for i, (actual, expected) in enumerate(zip(actuals, expecteds)):
-        assert (
-            actual.page_content == expected.page_content
-        ), f"{i}: page_content {actual.page_content} != {expected.page_content}"
-        assert (
-            actual.metadata == expected.metadata
-        ), f"{i}: metadata {actual.metadata} != {expected.metadata}"
-        if expected.id is not None:
-            assert actual.id == expected.id, f"{i}: id {actual.id} != {expected.id}"
-
-
-def test_aperturedb() -> None:
-    """Test end to end construction and search."""
-    docsearch = _aperturedb_from_texts()
-    output = docsearch.similarity_search("foo", k=1)
-    _compare_documents(output, [Document(page_content="foo")])
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_with_metadata() -> None:
-    """Test with metadata"""
-    docsearch = _aperturedb_from_texts(metadatas=[{"label": "test"}] * len(fake_texts))
-    output = docsearch.similarity_search("foo", k=1)
-    _compare_documents(
-        output, [Document(page_content="foo", metadata={"label": "test"})]
-    )
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_with_id() -> None:
-    """Test with ids"""
-    ids = ["id_" + str(i) for i in range(len(fake_texts))]
-    docsearch = _aperturedb_from_texts(ids=ids)
-    output: List[Document] = docsearch.similarity_search("foo", k=1)
-    _compare_documents(output, [Document(page_content="foo", id="id_0")])
-
-    output2: Optional[bool] = docsearch.delete(ids=ids)
-    assert output2
-
-    output3: List[Document] = docsearch.similarity_search("foo", k=1)
-    assert output3 == []
-
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_with_score() -> None:
-    """Test end to end construction and search with scores and IDs."""
-    metadatas = [{"page": i} for i in range(len(fake_texts))]
-    docsearch = _aperturedb_from_texts(metadatas=metadatas)
-    output = docsearch.similarity_search_with_score("foo", k=3)
-    docs = [o[0] for o in output]
-    scores = [o[1] for o in output]
-    _compare_documents(
-        docs,
-        [
-            Document(page_content="foo", metadata={"page": 0}),
-            Document(page_content="bar", metadata={"page": 1}),
-            Document(page_content="baz", metadata={"page": 2}),
-        ],
-    )
-    # scores descending by default (CS)
-    assert (
-        scores[0] > scores[1] > scores[2]
-    ), f"Expected {scores[0]} > {scores[1]} > {scores[2]}"
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_max_marginal_relevance_search() -> None:
-    """Test end to end construction and MRR search."""
-    metadatas = [{"page": i} for i in range(len(fake_texts))]
-    docsearch = _aperturedb_from_texts(metadatas=metadatas)
-    output = docsearch.max_marginal_relevance_search("foo", k=2, fetch_k=3)
-    _compare_documents(
-        output,
-        [
-            Document(page_content="foo", metadata={"page": 0}),
-            Document(page_content="bar", metadata={"page": 1}),
-        ],
-    )
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_add_extra() -> None:
-    """Test end to end construction and similarity search."""
-    texts = fake_texts
-    metadatas = [{"page": i} for i in range(len(texts))]
-    docsearch = _aperturedb_from_texts(metadatas=metadatas)
-
-    docsearch.add_texts(texts, metadatas)
-
-    output = docsearch.similarity_search("foo", k=10)
-    assert len(output) == 6, len(output)
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_add_extra_mmr() -> None:
-    """Test end to end construction and MRR search."""
-    texts = fake_texts
-    metadatas = [{"page": i} for i in range(len(texts))]
-    docsearch = _aperturedb_from_texts(metadatas=metadatas)
-
-    docsearch.add_texts(texts, metadatas)
-
-    output = docsearch.similarity_search("foo", k=10)
-    assert len(output) == 6, len(output)
-    ApertureDB.delete_vectorstore(docsearch.descriptor_set)
-
-
-def test_aperturedb_generate_ids() -> None:
-    """Test that the generated ids work correctly"""
-    descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
-    vectorstore = ApertureDB(embeddings=FakeEmbeddings(), descriptor_set=descriptor_set)
-    ids = vectorstore.add_texts(fake_texts)
-    docs = vectorstore.similarity_search("foo", k=10)
-    ids2 = [doc.id for doc in docs]
-    assert set(ids) == set(ids2), (ids, ids2)
-    ApertureDB.delete_vectorstore(vectorstore.descriptor_set)
-
-
-def test_aperturedb_upsert_entities() -> None:
-    """Test end to end construction and upsert entities"""
-    ids = [str(i) for i in range(len(fake_texts))]
-    vectorstore = _aperturedb_from_texts(ids=ids)
-    documents = [
-        Document(page_content="test1", id=1),
-        Document(page_content="test2", id=100),
-    ]
-    response = vectorstore.upsert(documents)
-    assert response["succeeded"] == ["1", "100"], response["succeeded"]
-    assert response["failed"] == [], response["failed"]
-    docs = vectorstore.similarity_search("foo", k=10)
-    ids.append("100")
-    docs_by_id = {doc.id: doc for doc in docs}
-    ids2 = set(docs_by_id.keys())
-    assert set(ids) == ids2, (ids, ids2)
-    assert docs_by_id["1"].page_content == "test1"
-    assert docs_by_id["100"].page_content == "test2"
-    ApertureDB.delete_vectorstore(vectorstore.descriptor_set)
-
-
-def test_aperturedb_upsert_empty() -> None:
-    """Test upsert when no ids are provided"""
-    ids = [str(i) for i in range(len(fake_texts))]
-    vectorstore = _aperturedb_from_texts(ids=ids)
-    documents = [
-        Document(page_content="test"),
-    ]
-    response = vectorstore.upsert(documents)
-    assert len(response["succeeded"]) == 1, response["succeeded"]
-    assert response["failed"] == [], response["failed"]
-    docs = vectorstore.similarity_search("foo", k=10)
-    ids.append(response["succeeded"][0])
-    docs_by_id = {doc.id: doc for doc in docs}
-    ids2 = set(docs_by_id.keys())
-    assert set(ids) == ids2, (ids, ids2)
-    assert docs_by_id[response["succeeded"][0]].page_content == "test"
-    ApertureDB.delete_vectorstore(vectorstore.descriptor_set)
-
-
-if __name__ == "__main__":
-    test_aperturedb()
-    test_aperturedb_with_metadata()
-    test_aperturedb_with_id()
-    test_aperturedb_with_score()
-    test_aperturedb_max_marginal_relevance_search()
-    test_aperturedb_add_extra()
-    test_aperturedb_add_extra_mmr()
-    test_aperturedb_generate_ids()
-    test_aperturedb_upsert_entities()
-    test_aperturedb_upsert_empty()
+class TestAsyncApertureDBReadWriteTestSuite(AsyncReadWriteTestSuite):
+    @pytest.fixture
+    async def vectorstore(self) -> ApertureDB:
+        descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
+        return ApertureDB(embeddings=self.get_embeddings(),
+            descriptor_set=descriptor_set)
+            

--- a/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_aperturedb.py
@@ -15,13 +15,15 @@ class TestApertureDBReadWriteTestSuite(ReadWriteTestSuite):
     @pytest.fixture
     def vectorstore(self) -> ApertureDB:
         descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
-        return ApertureDB(embeddings=self.get_embeddings(),
-            descriptor_set=descriptor_set)
+        return ApertureDB(
+            embeddings=self.get_embeddings(), descriptor_set=descriptor_set
+        )
 
 
 class TestAsyncApertureDBReadWriteTestSuite(AsyncReadWriteTestSuite):
     @pytest.fixture
     async def vectorstore(self) -> ApertureDB:
         descriptor_set = uuid.uuid4().hex  # Fresh descriptor set for each test
-        return ApertureDB(embeddings=self.get_embeddings(),
-            descriptor_set=descriptor_set)
+        return ApertureDB(
+            embeddings=self.get_embeddings(), descriptor_set=descriptor_set
+        )


### PR DESCRIPTION
Act on some feedback on the main PR:
* Use the new standard test suites instead of writing our own.  
* Put the main functionality into `upsert` and rely on default implementation of `add_documents` and `add_texts`.
* Implement new method `get_by_ids`